### PR TITLE
Add cache

### DIFF
--- a/pytus2000/__init__.py
+++ b/pytus2000/__init__.py
@@ -1,3 +1,4 @@
 from .version import __version__
 from .read import read_diary_file, read_individual_file
 from .datadicts import diary, diaryepisode, household, individual, weightdiary, worksheet
+from .cache import get_cache_location, set_cache_location, wipe_cache

--- a/pytus2000/cache.py
+++ b/pytus2000/cache.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+import json
+
+import pandas as pd
+
+from .version import __version__
+
+_CACHE_ROOT_PATH = Path('pytus-cache')
+
+
+def get_cache_location():
+    """Returns the directory into which caches are currently written to and from."""
+    return _Cache().cache_location
+
+
+def set_cache_location(cache_location):
+    """Sets the directory into which caches are currently written to and from."""
+    _Cache().cache_location = cache_location
+
+
+def wipe_cache():
+    """Empties the directory into which caches are currently written to and from."""
+    _Cache().wipe()
+
+
+class cached():
+    """Decorator caching return values of functions that always return the same pandas dataframe.
+
+    This is used to cache the time consuming reading of the pytus files for example. It
+    is based on an id, i.e. each cached function and the data set it produces has exactly
+    one id.
+    """
+
+    def __init__(self, cache_id):
+        self._cache_id = cache_id
+
+    def __call__(self, f):
+        def wrapped_f(*args):
+            return _Cache().use_cache_or_call(self._cache_id, f, *args)
+        return wrapped_f
+
+
+class _SingletonType(type):
+    """A meta class that creates classes applying the singleton pattern."""
+
+    def __call__(cls, *args, **kwargs):
+        try:
+            return cls.__instance
+        except AttributeError:
+            cls.__instance = super(_SingletonType, cls).__call__(*args, **kwargs)
+            return cls.__instance
+
+
+class _Cache(metaclass=_SingletonType):
+
+    def __init__(self):
+        self._cache_location = None
+
+    @property
+    def cache_location(self):
+        return self._cache_location
+
+    @cache_location.setter
+    def cache_location(self, new_cache_location):
+        if new_cache_location is None:
+            self._cache_location = None
+        else:
+            new_cache_location = Path(new_cache_location)
+            (new_cache_location / _CACHE_ROOT_PATH).mkdir(parents=True, exist_ok=True)
+            self._cache_location = new_cache_location
+
+    def wipe(self):
+        root_path = (self._cache_location / _CACHE_ROOT_PATH)
+        for path in root_path.rglob('*'):
+            path.unlink()
+        root_path.rmdir()
+
+    def use_cache_or_call(self, cache_id, read_function, *args):
+        if self._cache_location is not None:
+            path_to_cache = self._cache_location / _CACHE_ROOT_PATH / cache_id
+            if self._valid_cache_exists(cache_id):
+                return pd.read_pickle(path_to_cache)
+            else:
+                path_to_cache.parent.mkdir(parents=True, exist_ok=True)
+                path_to_metadata = path_to_cache.with_suffix('.json')
+                with path_to_metadata.open('w') as fmetadata:
+                    json.dump(self._create_cache_metadata(), fmetadata)
+                df = read_function(*args)
+                df.to_pickle(path_to_cache)
+                return df
+        else:
+            return read_function(*args)
+
+    def _valid_cache_exists(self, cache_id):
+        path_to_cache = self._cache_location / _CACHE_ROOT_PATH / cache_id
+        path_to_metadata = path_to_cache.with_suffix('.json')
+        if not path_to_cache.exists() or not path_to_metadata.exists():
+            return False
+        expected_metadata = self._create_cache_metadata()
+        with path_to_metadata.open('r') as fmetadata:
+            metadata = json.load(fmetadata)
+        return expected_metadata == metadata
+
+    @staticmethod
+    def _create_cache_metadata():
+        return {
+            'version.pytus2000': __version__,
+            'version.pandas': pd.__version__
+        }

--- a/pytus2000/read.py
+++ b/pytus2000/read.py
@@ -21,8 +21,7 @@ def read_diary_file(path_to_file):
     return _read_file(
         module=diary,
         index_columns=4,
-        path_to_file=path_to_file,
-        cache_id=_DIARY_DATA_CACHE_ID
+        path_to_file=path_to_file
     )
 
 
@@ -39,12 +38,11 @@ def read_individual_file(path_to_file):
     return _read_file(
         module=individual,
         index_columns=3,
-        path_to_file=path_to_file,
-        cache_id=_INDIVIDUAL_DATA_CACHE_ID
+        path_to_file=path_to_file
     )
 
 
-def _read_file(module, index_columns, path_to_file, cache_id):
+def _read_file(module, index_columns, path_to_file):
     converter_map = _column_name_to_type_mapping(module)
     data = pd.read_csv(
         path_to_file,

--- a/pytus2000/read.py
+++ b/pytus2000/read.py
@@ -2,8 +2,13 @@ import pandas as pd
 import numpy as np
 
 from .datadicts import diary, individual
+from .cache import cached
+
+_DIARY_DATA_CACHE_ID = 'diary-data'
+_INDIVIDUAL_DATA_CACHE_ID = 'individual-data'
 
 
+@cached(_DIARY_DATA_CACHE_ID)
 def read_diary_file(path_to_file):
     """Reads the tab-delimited diary data set.
 
@@ -16,10 +21,12 @@ def read_diary_file(path_to_file):
     return _read_file(
         module=diary,
         index_columns=4,
-        path_to_file=path_to_file
+        path_to_file=path_to_file,
+        cache_id=_DIARY_DATA_CACHE_ID
     )
 
 
+@cached(_INDIVIDUAL_DATA_CACHE_ID)
 def read_individual_file(path_to_file):
     """Reads the tab-delimited individual data set.
 
@@ -32,11 +39,12 @@ def read_individual_file(path_to_file):
     return _read_file(
         module=individual,
         index_columns=3,
-        path_to_file=path_to_file
+        path_to_file=path_to_file,
+        cache_id=_INDIVIDUAL_DATA_CACHE_ID
     )
 
 
-def _read_file(module, index_columns, path_to_file):
+def _read_file(module, index_columns, path_to_file, cache_id):
     converter_map = _column_name_to_type_mapping(module)
     data = pd.read_csv(
         path_to_file,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,101 @@
+"""Tests of the caching mechanism.
+
+These tests are slightly weird. It is difficult to test the caching mechanism without testing
+internals. The way this is done here is the following:
+
+The caching mechanism is based on ids. That is, each function and the dataframe it returns have
+an id. In the following tests, that mechanism is overwritten by two functions which have distinct
+return values but the same id. That way it can always be understood whether a return value is
+taken from the function or from cache.
+"""
+from pathlib import Path
+import os
+
+import pandas as pd
+from pandas.util.testing import assert_series_equal
+import pytest
+
+import pytus2000 as tus
+from pytus2000 import cache
+
+CACHE_ID = 'some-cache-id'
+DATA = pd.Series([1, 2, 3])
+OTHER_DATA = pd.Series([10, 20, 30])
+
+
+@pytest.fixture
+def function_returning_data():
+    def some_func():
+        return DATA
+    return cache.cached(CACHE_ID)(some_func)
+
+
+@pytest.fixture()
+def function_returning_other_data():
+    def some_func():
+        return OTHER_DATA
+    return cache.cached(CACHE_ID)(some_func)
+
+
+def test_writes_cache(tmpdir, function_returning_data):
+    tus.set_cache_location(str(tmpdir))
+    data = function_returning_data()
+    assert (Path(str(tmpdir)) / cache._CACHE_ROOT_PATH / CACHE_ID).exists()
+
+
+def test_returns_data_when_writing_to_cache(tmpdir, function_returning_data):
+    tus.set_cache_location(str(tmpdir))
+    data = function_returning_data()
+    assert_series_equal(data, DATA)
+
+
+def test_does_not_write_to_cache_if_switched_off(tmpdir, function_returning_data):
+    tus.set_cache_location(str(tmpdir))
+    tus.set_cache_location(None)
+    data = function_returning_data()
+    assert not (Path(str(tmpdir)) / cache._CACHE_ROOT_PATH / CACHE_ID).exists()
+
+
+def test_returns_data_when_switched_off(tmpdir, function_returning_data):
+    tus.set_cache_location(str(tmpdir))
+    tus.set_cache_location(None)
+    data = function_returning_data()
+    assert_series_equal(data, DATA)
+
+
+def test_reads_from_cache_if_valid(tmpdir, function_returning_data, function_returning_other_data):
+    tus.set_cache_location(str(tmpdir))
+    data_first = function_returning_data()
+
+    data_second = function_returning_other_data() # should return OTHER_DATA, but is read from cache
+    assert_series_equal(data_second, DATA)
+
+
+def test_does_not_read_from_cache_if_pytus_version_changes(tmpdir, function_returning_data,
+                                                           function_returning_other_data):
+    tus.cache.__version__ = '0.0.0.test'
+    tus.set_cache_location(str(tmpdir))
+    data_first = function_returning_data()
+
+    tus.cache.__version__ = '0.0.1.test'
+    data_second = function_returning_other_data()
+    assert_series_equal(data_second, OTHER_DATA)
+
+
+def test_does_not_read_from_cache_if_pandas_version_changes(tmpdir, function_returning_data,
+                                                            function_returning_other_data):
+    pd.__version__ = '0.0.0.test'
+    tus.set_cache_location(str(tmpdir))
+    data_first = function_returning_data()
+
+    pd.__version__ = '0.0.1.test'
+    data_second = function_returning_other_data()
+    assert_series_equal(data_second, OTHER_DATA)
+
+
+def test_allows_wiping_cache(tmpdir, function_returning_data):
+    tus.set_cache_location(str(tmpdir))
+    data = function_returning_data()
+
+    tus.wipe_cache()
+    assert not (Path(str(tmpdir)) / cache._CACHE_ROOT_PATH / CACHE_ID).exists()


### PR DESCRIPTION
This allows to cache data that has been previously been converted
from the tab delimited files (a proces that is slow). Using a cache
is a better option than permanently saving intermediary results, it
allows to very easily reproduce intermediate resulst from the raw
data.

Implements #21.